### PR TITLE
Use system UIDs and GIDs when creating accounts.

### DIFF
--- a/files/gitlab-cookbooks/gitlab/recipes/postgresql.rb
+++ b/files/gitlab-cookbooks/gitlab/recipes/postgresql.rb
@@ -24,6 +24,7 @@ postgresql_user = node['gitlab']['postgresql']['username']
 
 group postgresql_user do
   gid node['gitlab']['postgresql']['gid']
+  system true
 end
 
 user postgresql_user do

--- a/files/gitlab-cookbooks/gitlab/recipes/redis.rb
+++ b/files/gitlab-cookbooks/gitlab/recipes/redis.rb
@@ -22,6 +22,7 @@ redis_user = node['gitlab']['redis']['username']
 
 group redis_user do
   gid node['gitlab']['redis']['gid']
+  system true
 end
 
 user redis_user do

--- a/files/gitlab-cookbooks/gitlab/recipes/users.rb
+++ b/files/gitlab-cookbooks/gitlab/recipes/users.rb
@@ -27,6 +27,7 @@ end
 # Create the group for the GitLab user
 group gitlab_group do
   gid node['gitlab']['user']['gid']
+  system true
 end
 
 # Create the GitLab user
@@ -35,6 +36,7 @@ user gitlab_username do
   home gitlab_home
   uid node['gitlab']['user']['uid']
   gid gitlab_group
+  system true
 end
 
 # Configure Git settings for the GitLab user

--- a/files/gitlab-cookbooks/gitlab/recipes/web-server.rb
+++ b/files/gitlab-cookbooks/gitlab/recipes/web-server.rb
@@ -24,6 +24,7 @@ external_webserver_users = node['gitlab']['web-server']['external_users']
 # GitLab webserver group
 group webserver_group do
   gid node['gitlab']['web-server']['gid']
+  system true
   if external_webserver_users.any? && !node['gitlab']['nginx']['enable']
     append true
     members external_webserver_users
@@ -36,5 +37,6 @@ user webserver_username do
   home node['gitlab']['nginx']['dir']
   uid node['gitlab']['web-server']['uid']
   gid webserver_group
+  system true
   supports manage_home: false
 end


### PR DESCRIPTION
This ensures that accounts are created in the system UID/GID range rather than the normal user one. This was already done for the postgresql and redis users, but not the other two.
