### PR TITLE
fix image in docs path

### DIFF
--- a/doc/update.md
+++ b/doc/update.md
@@ -4,7 +4,7 @@
 
 Please make sure you are viewing this file on the master branch.
 
-![documentation version](doc/images/omnibus-documentation-version-update-md.png)
+![documentation version](images/omnibus-documentation-version-update-md.png)
 
 ## Updating from GitLab 6.6.x and higher to the latest version
 


### PR DESCRIPTION
Looks fine on https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/update.md but GitHub doesn't like the path. This should work on both GitLab and GitHub.
