### PR TITLE
add details on backing up your SSH host keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ sudo tar -xf etc-gitlab-1399948539.tar -C /
 Remember to run `sudo gitlab-ctl reconfigure` after restoring a configuration
 backup.
 
-NOTE: Your machines SSH host keys are stored in a seperate location at `/etc/ssh/`. Be sure to also [backup and restore those keys](https://superuser.com/questions/532040/copy-ssh-keys-from-one-server-to-another-server/532079#532079) to avoid man-in-the-middle attack warnings if you have to perform a full machine restore.
+NOTE: Your machines SSH host keys are stored in a separate location at `/etc/ssh/`. Be sure to also [backup and restore those keys](https://superuser.com/questions/532040/copy-ssh-keys-from-one-server-to-another-server/532079#532079) to avoid man-in-the-middle attack warnings if you have to perform a full machine restore.
 
 ### Configuring the external URL for GitLab
 


### PR DESCRIPTION
Users need to backup SSH keys if they want to do a complete restore to the same domain and not have users get the `WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!` and man-in-the-middle attack warning messages. Related to https://github.com/gitlabhq/gitlabhq/pull/8359.
