### PR TITLE
Fix unexpected escaping on LDAP configs

### DIFF
--- a/files/gitlab-config-template/gitlab.rb.template
+++ b/files/gitlab-config-template/gitlab.rb.template
@@ -47,7 +47,7 @@ external_url 'GENERATED_EXTERNAL_URL'
 ## yaml format and the spaces must be retained. Using tabs will not work.
 
 # gitlab_rails['ldap_enabled'] = false
-# gitlab_rails['ldap_servers'] = YAML.load <<-EOS # remember to close this block with 'EOS' below
+# gitlab_rails['ldap_servers'] = YAML.load <<-'EOS' # remember to close this block with 'EOS' below
 #   main: # 'main' is the GitLab 'provider ID' of this LDAP server
 #     label: 'LDAP'
 #     host: '_your_ldap_server'


### PR DESCRIPTION
It's possible that using UID for an LDAP server in the form of:
`domname\username`. In this case the slash will be escaped and
authentication will always fail. Since we're not using interpolation in
the config, it's better replace `EOS` with `'EOS'`.

Signed-off-by: kfei <kfei@kfei.net>