### PR TITLE
Respect gitlab_email_enabled property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The latest version of this file can be found at the master branch of the
 omnibus-gitlab repository.
 
+7.8.1
+
+- Respect gitlab_email_enabled property (Daniel Serodio)
+
 7.8.0
 
 - Add gitlab-ci to logrotate (François Conil) 397ce5bab202d9d86e30a62538dca1323b7f6f4c

--- a/files/gitlab-config-template/gitlab.rb.template
+++ b/files/gitlab-config-template/gitlab.rb.template
@@ -12,6 +12,7 @@ external_url 'GENERATED_EXTERNAL_URL'
 
 # gitlab_rails['gitlab_ssh_host'] = 'ssh.host_example.com'
 # gitlab_rails['time_zone'] = 'UTC'
+# gitlab_rails['gitlab_email_enabled'] = true
 # gitlab_rails['gitlab_email_from'] = 'example@example.com'
 # gitlab_rails['gitlab_default_projects_limit'] = 10
 # gitlab_rails['gitlab_default_can_create_group'] = true

--- a/files/gitlab-cookbooks/gitlab/templates/default/gitlab.yml.erb
+++ b/files/gitlab-cookbooks/gitlab/templates/default/gitlab.yml.erb
@@ -30,6 +30,8 @@ production: &base
     time_zone: <%= single_quote(@time_zone) %>
 
     ## Email settings
+    # Uncomment and set to false if you need to disable email sending from GitLab (default: true)
+    email_enabled: <%= @gitlab_email_enabled %>
     # Email address used in the "From" field in mails sent by GitLab
     email_from: <%= @gitlab_email_from %>
 


### PR DESCRIPTION
GitLab uses this property but `gitlab-ctl reconfigure` doesn't recognize this `gitlab.rb` setting.