### PR TITLE
Add sslmode support to pgsql database

### DIFF
--- a/files/gitlab-cookbooks/gitlab/attributes/default.rb
+++ b/files/gitlab-cookbooks/gitlab/attributes/default.rb
@@ -140,6 +140,8 @@ default['gitlab']['gitlab-rails']['db_password'] = nil
 default['gitlab']['gitlab-rails']['db_host'] = nil
 default['gitlab']['gitlab-rails']['db_port'] = 5432
 default['gitlab']['gitlab-rails']['db_socket'] = nil
+default['gitlab']['gitlab-rails']['db_sslmode'] = nil
+default['gitlab']['gitlab-rails']['db_sslrootcert'] = nil
 
 default['gitlab']['gitlab-rails']['redis_host'] = "127.0.0.1"
 default['gitlab']['gitlab-rails']['redis_port'] = nil

--- a/files/gitlab-cookbooks/gitlab/templates/default/database.yml.erb
+++ b/files/gitlab-cookbooks/gitlab/templates/default/database.yml.erb
@@ -12,3 +12,5 @@ production:
   host: <%= single_quote(@db_host) %>
   port: <%= @db_port %>
   socket: <%= single_quote(@db_socket) %>
+  socket: <%= single_quote(@db_sslmode) %>
+  socket: <%= single_quote(@db_sslrootcert) %>

--- a/files/gitlab-cookbooks/gitlab/templates/default/database.yml.erb
+++ b/files/gitlab-cookbooks/gitlab/templates/default/database.yml.erb
@@ -12,5 +12,5 @@ production:
   host: <%= single_quote(@db_host) %>
   port: <%= @db_port %>
   socket: <%= single_quote(@db_socket) %>
-  socket: <%= single_quote(@db_sslmode) %>
-  socket: <%= single_quote(@db_sslrootcert) %>
+  sslmode: <%= single_quote(@db_sslmode) %>
+  sslrootcert: <%= single_quote(@db_sslrootcert) %>


### PR DESCRIPTION
Add two ssl params into the database.yml configuration file : 
* sslmode : This option determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server
 * Default : prefer (first try an SSL connection; if that fails, try a non-SSL connection)
* sslrootcert : This parameter specifies the name of a file containing SSL certificate authority (CA) certificate(s)
 * Default : /var/opt/gitlab/.postgresql/root.crt

Documentation : http://www.postgresql.org/docs/current/static/libpq-ssl.html