### PR TITLE
add warning about what cron backup does not cover

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,12 +531,14 @@ There, add the following line to schedule the backup for everyday at 2 AM:
 
 You may also want to set a limited lifetime for backups to prevent regular
 backups using all your disk space.  To do this add the following lines to
-`/etc/gitlab/gitlab.rb` and reconfigure:-
+`/etc/gitlab/gitlab.rb` and reconfigure:
 
 ```
 # limit backup lifetime to 7 days - 604800 seconds
 gitlab_rails['backup_keep_time'] = 604800
 ```
+
+NOTE: This cron job does not [backup your omnibus-gitlab configuration](#backup-and-restore-omnibus-gitlab-configuration) or [SSH host keys](https://superuser.com/questions/532040/copy-ssh-keys-from-one-server-to-another-server/532079#532079).
 
 ### Restoring an application backup
 


### PR DESCRIPTION
Document that suggested backup via cron job does not backup omnibus-gitlab configuration or SSH host keys.