### PR TITLE
use CRON=1 for cron job based backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ crontab -e
 There, add the following line to schedule the backup for everyday at 2 AM:
 
 ```
-0 2 * * * /opt/gitlab/bin/gitlab-rake gitlab:backup:create
+0 2 * * * /opt/gitlab/bin/gitlab-rake gitlab:backup:create CRON=1
 ```
 
 You may also want to set a limited lifetime for backups to prevent regular


### PR DESCRIPTION
Per https://github.com/gitlabhq/gitlabhq/commit/7c54c63ac14eb8f5ce0e364d709988fcfe4dda64 use `CRON=1` for cron job based backup.