### PR TITLE
add packages link to 6.6+ to 7.10+

### DIFF
--- a/doc/update/README.md
+++ b/doc/update/README.md
@@ -13,7 +13,9 @@ configured the packages to run this command automatically after the new package
 is installed. If you are installing GitLab 7.9 or earlier, please see the
 [procedure below](#updating-from-gitlab-66-and-higher-to-the-latest-version).
 
-All you have to do is `dpkg -i gitlab-ce-XXX.deb` (for Debian/Ubuntu) or `rpm
+First, download the latest [CE](https://packages.gitlab.com/gitlab/gitlab-ce) or
+[EE (subscribers only)](https://packages.gitlab.com/gitlab/gitlab-ee)
+package to your GitLab server then all you have to do is `dpkg -i gitlab-ce-XXX.deb` (for Debian/Ubuntu) or `rpm
 -Uvh gitlab-ce-XXX.rpm` (for Centos/Enterprise Linux). After the package has
 been unpacked, GitLab will automatically:
 


### PR DESCRIPTION
Improves upgrade details by stating where to get packages.

Replaces #23.