### PR TITLE
make 'proxy_read_timeout' and 'proxy_connect_timeout' changeable via /etc/gitlab/gitlab.rb

### DIFF
--- a/files/gitlab-config-template/gitlab.rb.template
+++ b/files/gitlab-config-template/gitlab.rb.template
@@ -408,6 +408,8 @@ external_url 'GENERATED_EXTERNAL_URL'
 # nginx['listen_https'] = nil # override only if your reverse proxy internally communicates over HTTP: https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/settings/nginx.md#supporting-proxied-ssl
 # nginx['custom_gitlab_server_config'] = "location ^~ /foo-namespace/bar-project/raw/ {\n deny all;\n}\n"
 # nginx['custom_nginx_config'] = "include /etc/nginx/conf.d/example.conf;"
+# nginx['proxy_read_timeout'] = 300
+# nginx['proxy_connect_timeout'] = 300
 
 ## Advanced settings
 # nginx['dir'] = "/var/opt/gitlab/nginx"

--- a/files/gitlab-cookbooks/gitlab/attributes/default.rb
+++ b/files/gitlab-cookbooks/gitlab/attributes/default.rb
@@ -376,6 +376,8 @@ default['gitlab']['nginx']['listen_port'] = nil # override only if you have a re
 default['gitlab']['nginx']['listen_https'] = nil # override only if your reverse proxy internally communicates over HTTP
 default['gitlab']['nginx']['custom_gitlab_server_config'] = nil
 default['gitlab']['nginx']['custom_nginx_config'] = nil
+default['gitlab']['nginx']['proxy_read_timeout'] = 300
+default['gitlab']['nginx']['proxy_connect_timeout'] = 300
 
 ###
 # Logging

--- a/files/gitlab-cookbooks/gitlab/templates/default/nginx-gitlab-ci-http.conf.erb
+++ b/files/gitlab-cookbooks/gitlab/templates/default/nginx-gitlab-ci-http.conf.erb
@@ -68,8 +68,8 @@ server {
 
     ## https://github.com/gitlabhq/gitlabhq/issues/694
     ## Some requests take more than 30 seconds.
-    proxy_read_timeout      300;
-    proxy_connect_timeout   300;
+    proxy_read_timeout      <%= @proxy_read_timeout %>;
+    proxy_connect_timeout   <%= @proxy_connect_timeout %>;
     proxy_redirect          off;
 
     proxy_set_header   X-Forwarded-Proto <%= @https ? "https" : "http" %>;

--- a/files/gitlab-cookbooks/gitlab/templates/default/nginx-gitlab-http.conf.erb
+++ b/files/gitlab-cookbooks/gitlab/templates/default/nginx-gitlab-http.conf.erb
@@ -108,8 +108,8 @@ server {
 
     ## https://github.com/gitlabhq/gitlabhq/issues/694
     ## Some requests take more than 30 seconds.
-    proxy_read_timeout      300;
-    proxy_connect_timeout   300;
+    proxy_read_timeout      <%= @proxy_read_timeout %>;
+    proxy_connect_timeout   <%= @proxy_connect_timeout %>;
     proxy_redirect          off;
 
     proxy_set_header    Host                $http_host;
@@ -133,8 +133,8 @@ server {
 
     ## https://github.com/gitlabhq/gitlabhq/issues/694
     ## Some requests take more than 30 seconds.
-    proxy_read_timeout      300;
-    proxy_connect_timeout   300;
+    proxy_read_timeout      <%= @proxy_read_timeout %>;
+    proxy_connect_timeout   <%= @proxy_connect_timeout %>;
     proxy_redirect          off;
 
     proxy_set_header    Host                $http_host;

--- a/files/gitlab-cookbooks/gitlab/templates/default/nginx-gitlab-mattermost-http.conf.erb
+++ b/files/gitlab-cookbooks/gitlab/templates/default/nginx-gitlab-mattermost-http.conf.erb
@@ -55,8 +55,8 @@ server {
     ## to be safe against BREACH attack.
     <%= 'gzip off;' if @https %>
 
-    proxy_read_timeout      300;
-    proxy_connect_timeout   300;
+    proxy_read_timeout      <%= @proxy_read_timeout %>;
+    proxy_connect_timeout   <%= @proxy_connect_timeout %>;
     proxy_redirect          off;
 
     proxy_set_header   X-Forwarded-Proto <%= @https ? "https" : "http" %>;


### PR DESCRIPTION
instead of hard-coded in nginx-gitlab-http.conf.erb