### PR TITLE
Make proxy_\w+_timeouts in nginx-gitlab-http.conf.erb editable

### DIFF
--- a/files/gitlab-cookbooks/gitlab/templates/default/nginx-gitlab-http.conf.erb
+++ b/files/gitlab-cookbooks/gitlab/templates/default/nginx-gitlab-http.conf.erb
@@ -156,8 +156,8 @@ server {
 
     ## https://github.com/gitlabhq/gitlabhq/issues/694
     ## Some requests take more than 30 seconds.
-    proxy_read_timeout      300;
-    proxy_connect_timeout   300;
+    proxy_read_timeout      <%= @proxy_read_timeout %>;
+    proxy_connect_timeout   <%= @proxy_connect_timeout %>;
     proxy_redirect          off;
 
     # Do not buffer Git HTTP responses


### PR DESCRIPTION
Now all 'proxy_read_timeout' and 'proxy_connect_timeout' parameters in
the [-\/\w\.]+\.git location inside nginx-gitlab-http.conf.erb use named
parameters from /etc/gitlab/gitlab.rb instead of hard-coded values.