### PR TITLE
Fix wrapper to receive SIGTERM from docker

### DIFF
--- a/docker/assets/wrapper
+++ b/docker/assets/wrapper
@@ -63,4 +63,7 @@ echo "Configuring GitLab..."
 gitlab-ctl reconfigure
 
 # Tail all logs
-gitlab-ctl tail
+gitlab-ctl tail &
+
+# Wait for SIGTERM
+wait


### PR DESCRIPTION
Run gitlab-ctl tail in background to detach STDIN, so that the wrapper
script can receive a SIGTERM signal sent from the docker daemon.