### PR TITLE
improve self signed certificate/ca details

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -21,6 +21,7 @@
 - [Changing the name of the git user group](settings/configuration.md#changing-the-name-of-the-git-user-group)
 - [Specify numeric user and group identifiers](settings/configuration.md#specify-numeric-user-and-group-identifiers)
 - [Only start omnibus-gitlab services after a given filesystem is mounted](settings/configuration.md#only-start-omnibus-gitlab-services-after-a-given-filesystem-is-mounted)
+- [Using self signed certificate or custom certificate authorities](settings/configuration.md#using-self-signed-certificate-or-custom-certificate-authorities)
 - [SMTP](settings/smtp.md)
 - [NGINX](settings/nginx.md)
 - [LDAP](settings/ldap.md)

--- a/doc/common_installation_problems/README.md
+++ b/doc/common_installation_problems/README.md
@@ -265,29 +265,6 @@ PassThroughPattern: (packages\.gitlab\.com|packages-gitlab-com\.s3\.amazonaws\.c
 
 Read more about `apt-cacher-ng` and the reasons why this change is needed [on the packagecloud blog](http://blog.packagecloud.io/eng/2015/05/05/using-apt-cacher-ng-with-ssl-tls/).
 
-### Using self signed certificate or custom certificate authorities
-
-Omnibus-gitlab is shipped with the official [CAcert.org][] collection of trusted root certification authorities which are used to verify certificate authenticity.
-
-If you are installing GitLab in an isolated network with custom certificate authorities or using self signed certificate make sure that the certificate can be reached by GitLab. Not doing so will cause errors like:
-
-```bash
-Faraday::SSLError (SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed)
-```
-
-when GitLab tries to connect with the internal services like gitlab-shell or GitLab CI.
-
-To install individual certificates you need to:
-
-1. Place your certificate in `/opt/gitlab/embedded/ssl/certs/` directory; For example, `/opt/gitlab/embedded/ssl/certs/customcacert.pem`
-1. Create the hash-based symlink to the newly created `customcacert.pem`. For example, You can use [certificate link shell script][], [script source][] . *NOTE* If you end up using the script, make sure the script is executable with `chmod +x certlink.sh`. After making it executable you can do: `certlink.sh customcacert.pem` while in `/opt/gitlab/embedded/ssl/certs/`.
-
-After the custom certificate is symlinked the errors should be gone and your custom certificate preserved on GitLab upgrades.
-
-Make sure to have the backup of the certificate as GitLab is not backing up `/opt/gitlab/` contents.
-
-If you are using self-signed certificate do not forget to set `self_signed_cert: true` for gitlab-shell, see [gitlab.rb.template][] for more details.
-
 ### Error executing action create on resource cron[gitlab-ci schedule builds]
 
 1. Double check if you have cron package installed: For Debian like systems `sudo apt-get install cron` or RHEL-like systems `sudo yum install cronie`

--- a/doc/settings/configuration.md
+++ b/doc/settings/configuration.md
@@ -215,6 +215,38 @@ high_availability['mountpoint'] = '/var/opt/gitlab'
 
 Run `sudo gitlab-ctl reconfigure` for the change to take effect.
 
+## Using self signed certificate or custom certificate authorities
+
+Omnibus-gitlab is shipped with the official [CAcert.org][] collection of trusted root certification authorities which are used to verify certificate authenticity.
+
+If you are installing GitLab in an isolated network with custom certificate authorities or using self signed certificate make sure that the certificate can be reached by GitLab. Not doing so will cause errors like:
+
+```bash
+Faraday::SSLError (SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed)
+```
+
+when GitLab tries to connect with the internal services like gitlab-shell, GitLab CI, web hooks, or system hooks.
+
+To install individual certificates you need to:
+
+1. Run `sudo mkdir -m 755 -p /etc/gitlab/CA` and place your certificates files in `/etc/gitlab/CA`
+1. Fix permissions on certificates files: `sudo chmod uog+r /etc/gitlab/CA/*`
+1. Create the hash-based symlink to the newly created certificates files:
+
+  ```
+  sudo nano /opt/gitlab/embedded/ssl/certs/certlink.sh
+  # Paste from https://gitlab.com/snippets/6285
+  sudo chmod +x /opt/gitlab/embedded/ssl/certs/certlink.sh
+  cd /opt/gitlab/embedded/ssl/certs/
+  sudo ./certlink.sh /etc/gitlab/CA/*
+  ```
+
+After the custom certificates are symlinked the errors should be gone and your custom certificates preserved on GitLab upgrades.
+
+Make sure to backup the certificates as GitLab is not backing up `/etc/gitlab/` contents. See [backups](doc/settings/backups.md) for suggested configuration backup strategies.
+
+If you are using self-signed certificate do not forget to set `self_signed_cert: true` for gitlab-shell, see [gitlab.rb.template][] for more details.
+
 ### Setting up LDAP sign-in
 
 See [doc/settings/ldap.md](ldap.md).


### PR DESCRIPTION
Improve instructions on how to add self signed certs/customer CAs. This is needed until https://gitlab.com/gitlab-org/omnibus-gitlab/issues/712 is addressed.
