### PR TITLE
Update incorrect command for uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ sudo rpm -e gitlab-ce
 
 To remove all omnibus-gitlab data use `sudo gitlab-ctl cleanse`.
 
-To remove all users and groups created by omnibus-gitlab, before removing the gitlab package (with dpkg or yum) run `sudo gitlab-ctl remove_users`. *Note* All gitlab processes need to be stopped before runnign the command.
+To remove all users and groups created by omnibus-gitlab, before removing the gitlab package (with dpkg or yum) run `sudo gitlab-ctl remove-accounts`. *Note* All gitlab processes need to be stopped before running the command.
 
 ### Common installation problems
 


### PR DESCRIPTION
The command `sudo gitlab-ctl remove_users` does not exist.

I assume that the command `sudo gitlab-ctl remove-accounts` is what we want here.

```
$ sudo gitlab-ctl help
/opt/gitlab/embedded/bin/omnibus-ctl: command (subcommand)
...
remove-accounts
  Delete *all* users and groups used by this package
...

```

I'm using gitlab-ce 8.2.1 e53c0c5