### PR TITLE
Use listen_network for gitlab-workhorse upstream

### DIFF
--- a/files/gitlab-cookbooks/gitlab/templates/default/nginx-gitlab-http.conf.erb
+++ b/files/gitlab-cookbooks/gitlab/templates/default/nginx-gitlab-http.conf.erb
@@ -31,7 +31,7 @@
 ###################################
 
 upstream gitlab-workhorse {
-  server unix:<%= node['gitlab']['gitlab-workhorse']['listen_addr'] %>;
+  server <%= node['gitlab']['gitlab-workhorse']['listen_network'] %>:<%= node['gitlab']['gitlab-workhorse']['listen_addr'] %>;
 }
 
 <% if @https && @redirect_http_to_https %>


### PR DESCRIPTION
Remove hardcoded "unix" listen_network for gitlab-workhorse upstream, to use configuration file value instead.