### PR TITLE
Icon and category update to OpenShift template

### DIFF
--- a/docker/openshift-template.json
+++ b/docker/openshift-template.json
@@ -4,9 +4,9 @@
   "metadata": {
     "name": "gitlab-ce",
     "annotations": {
-      "iconClass": "fa fa-git",
+      "iconClass": "icon-gitlab",
       "description": "GitLab. Collaboration and source control management: code, test, and deploy together! \n\n GitLab requries that the serviceaccount for the main GitLab app be added to the anyuid security context. The service account name is: <application name>-user",
-      "tags": "instant-app,gitlab,VCS"
+      "tags": "instant-app,gitlab,VCS,ci-cd"
     }
   },
   "labels": {


### PR DESCRIPTION
- Change OpenShift template icon to GitLab's icon
- Make template available under 'Continuous Integration & Deployment' category